### PR TITLE
Inherit styles from UI theme

### DIFF
--- a/stylesheets/show-todo.less
+++ b/stylesheets/show-todo.less
@@ -14,12 +14,12 @@
 
 @import "syntax-variables";
 
-@font-family: "Helvetica Neue", Helvetica, sans-serif;
 .show-todo-preview {
   font-family: @font-family;
   font-size: 14px;
   line-height: 1.6;
-  background-color: #fff;
+  background-color: @base-background-color;
+  color: @text-color;
   overflow: scroll;
   box-sizing: border-box;
   padding: 20px;
@@ -55,10 +55,10 @@
   }
 
   .result_heading_title {
-    border-bottom: 1px solid #eee;
+    border-bottom: 1px solid @text-color-subtle;
 
     .regex {
-      color: #aaa;
+      color: @text-color-subtle;
       font-size: 14px;
     }
   }
@@ -74,7 +74,7 @@
   // }
   //
   a {
-    color: #4183c4;
+    color: @text-color-info;
   }
   //
   // ol > li {
@@ -95,7 +95,7 @@
   //
   // Link Colors
   a.absent {
-    color: #c00;
+    color: @text-color-error;
   }
 
   a.anchor {
@@ -310,10 +310,10 @@
 
     tr {
       // border-top: 1px solid #ccc;
-      background-color: #fff;
+      background-color: @base-background-color;
 
       &:nth-child(2n) {
-        background-color: #f8f8f8;
+        background-color: lighten(@base-background-color, 1%);
       }
     }
   }

--- a/stylesheets/show-todo.less
+++ b/stylesheets/show-todo.less
@@ -1,17 +1,4 @@
-// The ui-variables file is provided by base themes provided by Atom.
-//
-// See https://github.com/atom/atom-dark-ui/blob/master/stylesheets/ui-variables.less
-// for a full listing of what's available.
 @import "ui-variables";
-
-// .show-todo-preview {
-//   background: #666;
-//   padding: 20px;
-//   // width: 600px;
-//
-// }
-
-
 @import "syntax-variables";
 
 .show-todo-preview {
@@ -63,37 +50,12 @@
     }
   }
 
+  // Link Colors
 
-
-  // pre,
-  // pre div.editor,
-  // code,
-  // tt {
-  //   font-size: 12px;
-  //   font-family: Consolas, "Liberation Mono", Courier, monospace;
-  // }
-  //
   a {
     color: @text-color-info;
   }
-  //
-  // ol > li {
-  //   list-style-type: decimal;
-  // }
-  //
-  // ul > li {
-  //   list-style-type: disc;
-  // }
-  //
-  // & > *:first-child {
-  //   margin-top: 0 !important;
-  // }
-  //
-  // & > *:last-child {
-  //   margin-bottom: 0 !important;
-  // }
-  //
-  // Link Colors
+
   a.absent {
     color: @text-color-error;
   }
@@ -139,163 +101,7 @@
       font-size: inherit;
     }
   }
-  //
-  // h1 {
-  //   font-size: 28px;
-  //   color: #000;
-  // }
-  //
-  // h2 {
-  //   font-size: 24px;
-  //   border-bottom: 1px solid #ccc;
-  //   color: #000;
-  // }
-  //
-  // h3 {
-  //   font-size: 18px;
-  // }
-  //
-  // h4 {
-  //   font-size: 16px;
-  // }
-  //
-  // h5 {
-  //   font-size: 14px;
-  // }
-  //
-  // h6 {
-  //   color: #777;
-  //   font-size: 14px;
-  // }
-  //
-  // p,
-  // blockquote,
-  // ul, ol, dl,
-  // table,
-  // pre {
-  //   margin: 15px 0;
-  // }
-  //
-  // hr {
-  //   background: transparent;
-  //   border: 0 none;
-  //   color: #ccc;
-  //   height: 4px;
-  //   padding: 0;
-  // }
-  //
-  // & > h2:first-child,
-  // & > h1:first-child,
-  // & > h1:first-child + h2,
-  // & > h3:first-child,
-  // & > h4:first-child,
-  // & > h5:first-child,
-  // & > h6:first-child {
-  //   margin-top: 0;
-  //   padding-top: 0;
-  // }
-  //
-  // // fixes margin on shit like:
-  // // <a name='the-heading'>
-  // // <h1>The Heading</h1></a>
-  // a:first-child {
-  //   h1, h2, h3, h4, h5, h6 {
-  //     margin-top: 0;
-  //     padding-top: 0;
-  //   }
-  // }
-  //
-  // h1 + p,
-  // h2 + p,
-  // h3 + p,
-  // h4 + p,
-  // h5 + p,
-  // h6 + p {
-  //   margin-top: 0;
-  // }
-  //
-  // // ReST first graf in nested list
-  // li p.first {
-  //   display: inline-block;
-  // }
-  //
-  // // Lists, Blockquotes & Such
-  // ul, ol {
-  //   padding-left: 30px;
-  //
-  //   &.no-list {
-  //     list-style-type: none;
-  //     padding: 0;
-  //   }
-  //
-  //   li > :first-child,
-  //   li ul:first-of-type {
-  //     margin-top: 0;
-  //   }
-  // }
-  //
-  // ul ul,
-  // ul ol,
-  // ol ol,
-  // ol ul {
-  //   margin-bottom: 0;
-  // }
-  //
-  // dl {
-  //   padding: 0;
-  // }
-  //
-  // dl dt {
-  //   font-size: 14px;
-  //   font-weight: bold;
-  //   font-style: italic;
-  //   padding: 0;
-  //   margin: 15px 0 5px;
-  //
-  //   &:first-child {
-  //     padding: 0;
-  //   }
-  //   & > :first-child {
-  //     margin-top: 0;
-  //   }
-  //
-  //   & > :last-child {
-  //     margin-bottom: 0;
-  //   }
-  // }
-  //
-  // dl dd {
-  //   margin: 0 0 15px;
-  //   padding: 0 15px;
-  //   & > :first-child {
-  //     margin-top: 0;
-  //   }
-  //
-  //   & > :last-child {
-  //     margin-bottom: 0;
-  //   }
-  // }
-  //
-  // blockquote {
-  //   border-left: 4px solid #DDD;
-  //   padding: 0 15px;
-  //   color: #777;
-  //
-  //   & > :first-child {
-  //     margin-top: 0;
-  //   }
-  //
-  //   & > :last-child {
-  //     margin-bottom: 0;
-  //   }
-  //
-  //   p {
-  //     font-size: 16px;
-  //     line-height: 1.5;
-  //   }
-  // }
-  //
-  // // Tables
+
   table {
 
     th {
@@ -303,13 +109,11 @@
     }
 
     th, td {
-    //   border: 1px solid #ccc;
       font-size: 14px;
       padding: 6px 6px;
     }
 
     tr {
-      // border-top: 1px solid #ccc;
       background-color: @base-background-color;
 
       &:nth-child(2n) {
@@ -317,148 +121,4 @@
       }
     }
   }
-  //
-  // // Images & Stuff
-  // img {
-  //   max-width: 100%;
-  // }
-  //
-  // // Gollum Image Tags
-  //
-  // // Framed
-  // span.frame {
-  //   display: block;
-  //   overflow: hidden;
-  //
-  //   & > span {
-  //     border: 1px solid #ddd;
-  //     display: block;
-  //     float: left;
-  //     overflow: hidden;
-  //     margin: 13px 0 0;
-  //     padding: 7px;
-  //     width: auto;
-  //   }
-  //
-  //   span img {
-  //     display: block;
-  //     float: left;
-  //   }
-  //
-  //   span span {
-  //     clear: both;
-  //     color: #333;
-  //     display: block;
-  //     padding: 5px 0 0;
-  //   }
-  // }
-  //
-  // span.align-center {
-  //   display: block;
-  //   overflow: hidden;
-  //   clear: both;
-  //
-  //   & > span {
-  //     display: block;
-  //     overflow: hidden;
-  //     margin: 13px auto 0;
-  //     text-align: center;
-  //   }
-  //
-  //   span img {
-  //     margin: 0 auto;
-  //     text-align: center;
-  //   }
-  // }
-  //
-  // span.align-right {
-  //   display: block;
-  //   overflow: hidden;
-  //   clear: both;
-  //
-  //   & > span {
-  //     display: block;
-  //     overflow: hidden;
-  //     margin: 13px 0 0;
-  //     text-align: right;
-  //   }
-  //
-  //   span img {
-  //     margin: 0;
-  //     text-align: right;
-  //   }
-  // }
-  //
-  // span.float-left {
-  //   display: block;
-  //   margin-right: 13px;
-  //   overflow: hidden;
-  //   float: left;
-  //
-  //   span {
-  //     margin: 13px 0 0;
-  //   }
-  // }
-  //
-  // span.float-right {
-  //   display: block;
-  //   margin-left: 13px;
-  //   overflow: hidden;
-  //   float: right;
-  //
-  //   & > span {
-  //     display: block;
-  //     overflow: hidden;
-  //     margin: 13px auto 0;
-  //     text-align: right;
-  //   }
-  // }
-  //
-  // // Inline code snippets
-  // code, tt {
-  //   margin: 0 2px;
-  //   padding: 0 5px;
-  //   border: 1px solid #eaeaea;
-  //   background-color: #f8f8f8;
-  //   border-radius:3px;
-  //   text-shadow: none;
-  // }
-  //
-  // code { white-space: nowrap; }
-  //
-  // // Code tags within code blocks (<pre>s)
-  // pre > code {
-  //   margin: 0;
-  //   padding: 0;
-  //   white-space: pre;
-  //   border: none;
-  //   background: transparent;
-  // }
-  //
-  // pre {
-  //   background: #f8f8f8;
-  //   border: 1px solid #ccc;
-  //   font-size: 13px;
-  //   line-height: 19px;
-  //   overflow: auto;
-  //   padding: 6px 10px;
-  //   border-radius:3px;
-  // }
-  //
-  // // pre.editor-colors {
-  // //   background: @syntax-background-color;
-  // //   border: 1px solid darken(@syntax-background-color, 10%);
-  // // }
-  //
-  // pre code, pre tt {
-  //   margin: 0;
-  //   padding: 0;
-  //   background-color: transparent;
-  //   border: none;
-  // }
-  //
-  // .emoji {
-  //   height: 20px;
-  //   width: 20px;
-  // }
 }

--- a/stylesheets/show-todo.less
+++ b/stylesheets/show-todo.less
@@ -1,21 +1,6 @@
 @import "ui-variables";
 @import "syntax-variables";
 
-.show-todo-preview {
-  font-family: @font-family;
-  font-size: 14px;
-  line-height: 1.6;
-  background-color: @base-background-color;
-  color: @text-color;
-  overflow: scroll;
-  box-sizing: border-box;
-  padding: 20px;
-
-  :not(.editor-colors) > code {
-    color: #333;
-  }
-}
-
 .markdown-spinner {
   margin: auto;
   background-image: url(images/octocat-spinner-128.gif);
@@ -30,6 +15,18 @@
 // container with .markdown-preview on it should render generally well. It also
 // includes some GitHub Flavored Markdown specific styling (like @mentions)
 .show-todo-preview {
+  font-family: @font-family;
+  font-size: 14px;
+  line-height: 1.6;
+  background-color: @base-background-color;
+  color: @text-color;
+  overflow: scroll;
+  box-sizing: border-box;
+  padding: 20px;
+
+  :not(.editor-colors) > code {
+    color: #333;
+  }
 
   //FIXME: This CSS is a mess. really needs to be cleaned up
   .file_url {
@@ -80,30 +77,9 @@
     -webkit-font-smoothing: antialiased;
     cursor: text;
     position: relative;
-
-    .octicon-link {
-      display: none;
-      color: #000;
-    }
-
-    &:hover a.anchor {
-      text-decoration: none;
-      line-height: 1;
-      padding-left: 0;
-      margin-left: -22px;
-      top: 15%;
-
-      .octicon-link {
-        display: inline-block;
-      }
-    }
-    tt, code {
-      font-size: inherit;
-    }
   }
 
   table {
-
     th {
       font-weight: bold;
     }


### PR DESCRIPTION
While looking for a way to display TODO's in my files, I found this package which does the trick nicely. Great job!

One thing I noticed though was that the results contrasted quite strongly with the rest of atom's UI. As I was about to add some styles to my user stylesheet to fix this, I realized it would be better if the package just picked up my UI themes styles. So here I am.

While I was in `show-todo.less`, I noticed there were a lot of unused styles. I added a few commits to clean it up a little, but anything after 9758249 is really just extra, so I guess include those at your discretion.

Let me know if anything is wrong. Thanks!