### PR TITLE
Toggle todo view and test

### DIFF
--- a/lib/show-todo.coffee
+++ b/lib/show-todo.coffee
@@ -30,11 +30,8 @@ module.exports =
     ]
 
   activate: (state) ->
-    # atom.workspaceView.command 'todo-show:find-in-project', =>
     atom.commands.add 'atom-workspace', 'todo-show:find-in-project': =>
-    # @disposables.add atom.commands.add 'atom-workspace', 'todo-show:find-in-project': -> #this one is tied to the one in package.json
       @show()
-    # @show()
     # @showTodoView = new ShowTodoView(state.showTodoViewState)
 
     # register the todolist URI. Which will then open our custom view
@@ -52,30 +49,28 @@ module.exports =
   #     console.log(e)
 
   deactivate: ->
-    @showTodoView.destroy()
+    @showTodoView?.destroy()
     #CHANGED
     #NOTE:
   serialize: ->
-    showTodoViewState: @showTodoView.serialize()
+    showTodoViewState: @showTodoView?.serialize()
 
-  show: (todoContent )->
-    # editor = atom.workspace.getActiveEditor()
-    # return unless editor?
-
-    # unless editor.getGrammar().scopeName is "source.gfm"
-    #   console.warn("Cannot render markdown for '#{editor.getURI() ? 'untitled'}'")
-    #   return
-    #
-    # unless fs.isFileSync(editor.getPath())
-    #   console.warn("Cannot render markdown for '#{editor.getPath() ? 'untitled'}'")
-    #   return
-
+  show: ->
     previousActivePane = atom.workspace.getActivePane()
     uri = "todolist-preview://TODOs"
-    atom.workspace.open(uri, split: 'right', searchAllPanes: true).done (showTodoView) ->
-      # TODO: we could require it in, and use a similar pattern as the other one...
-      # console.log(arguments)
-      arguments[0].innerHTML = "WE HAVE LIFTOFF"
-      if showTodoView instanceof ShowTodoView
-        showTodoView.renderTodos() #do the initial render
-      previousActivePane.activate()
+    pane = atom.workspace.paneForItem(@showTodoView)
+    
+    if pane
+      pane.destroyItem(@showTodoView)
+      # ignore core.destroyEmptyPanes and close empty pane
+      pane.destroy() if pane.getItems().length is 0
+    else
+      atom.workspace.open(uri, split: 'right', searchAllPanes: true).done (textEditorView) =>
+        @showTodoView = textEditorView;
+
+        # TODO: we could require it in, and use a similar pattern as the other one...
+        
+        arguments[0].innerHTML = "WE HAVE LIFTOFF"
+        if @showTodoView instanceof ShowTodoView
+          @showTodoView.renderTodos() #do the initial render
+        previousActivePane.activate()

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "version": "0.8.0",
   "private": true,
   "description": "Finds all the TODOs, FIXMEs, CHANGEDs in your project.",
-  "activationEvents": [
-    "todo-show:find-in-project"
-  ],
+  "activationCommands": {
+    "atom-workspace": "todo-show:find-in-project"
+  },
   "repository": "https://github.com/jamischarles/atom-todo-show",
   "license": "MIT",
   "engines": {

--- a/spec/show-todo-spec.coffee
+++ b/spec/show-todo-spec.coffee
@@ -2,30 +2,31 @@
 
 ShowTodo = require '../lib/show-todo'
 
-# Use the command `window:run-package-specs` (cmd-alt-ctrl-p) to run specs.
-#
-# To run a specific `it` or `describe` block add an `f` to the front (e.g. `fit`
-# or `fdescribe`). Remove the `f` to unfocus the block.
-#
-# describe "ShowTodo", ->
-#   activationPromise = null
-#
-#   beforeEach ->
-#     atom.workspaceView = new WorkspaceView
-#     activationPromise = atom.packages.activatePackage('showTodo')
-#
-#   describe "when the show-todo:toggle event is triggered", ->
-#     it "attaches and then detaches the view", ->
-#       expect(atom.workspaceView.find('.show-todo')).not.toExist()
-#
-#       # This is an activation event, triggering it will cause the package to be
-#       # activated.
-#       atom.workspaceView.trigger 'show-todo:toggle'
-#
-#       waitsForPromise ->
-#         activationPromise
-#
-#       runs ->
-#         expect(atom.workspaceView.find('.show-todo')).toExist()
-#         atom.workspaceView.trigger 'show-todo:toggle'
-#         expect(atom.workspaceView.find('.show-todo')).not.toExist()
+describe 'ShowTodo', ->
+  [workspaceElement, activationPromise] = []
+
+  # needed to activate packages that are using activationCommands
+  executeCommand = (callback) ->
+    atom.commands.dispatch(workspaceElement, 'todo-show:find-in-project')
+    waitsForPromise -> activationPromise
+    runs(callback)
+
+  beforeEach ->
+    workspaceElement = atom.views.getView(atom.workspace)
+    #atom.workspaceView = workspaceElement.__spacePenView
+    #jasmine.attachToDOM(workspaceElement)
+    activationPromise = atom.packages.activatePackage('todo-show')
+
+  describe 'when the show-todo:find-in-project event is triggered', ->
+    it 'attaches and then detaches the pane view', ->
+      expect(atom.packages.loadedPackages["todo-show"]).toBeDefined()
+      
+      expect(workspaceElement.querySelector('.show-todo-preview')).not.toExist()
+      
+      # open todo-show
+      executeCommand ->
+        expect(workspaceElement.querySelector('.show-todo-preview')).toExist()
+
+        # close todo-show again
+        executeCommand ->
+          expect(workspaceElement.querySelector('.show-todo-preview')).not.toExist()

--- a/spec/show-todo-view-spec.coffee
+++ b/spec/show-todo-view-spec.coffee
@@ -7,7 +7,6 @@
 # - look at symbol generator for extracting comment blocks
 
 ShowTodoView = require '../lib/show-todo-view'
-{WorkspaceView} = require 'atom'
 
 # describe "ShowTodoView", ->
   # it "has one valid test", ->


### PR DESCRIPTION
I added the todo view toggle functionality with matching spec tests. Also to get this to work probably I had to change the deprecated activationEvents.

This should close #25 and #46, and remove a little of the deprecated warnings.

@jamischarles; if you grant shared git access I will take care of specs and deprecation warnings coming in up to Atoms major bump at the end of the month.