### PR TITLE
Feature/mimic language todo

### DIFF
--- a/lib/show-todo.coffee
+++ b/lib/show-todo.coffee
@@ -9,15 +9,23 @@ module.exports =
     # title, regex, title, regex...
     findTheseRegexes:
       type: 'array'
-      default: [
+      default: [ # based on atom/language-todo
         'FIXMEs'
-        '/FIXME:?(.+$)/g'
+        '/\\b@?FIXME:?(.+$)/g'
         'TODOs'
-        '/TODO:?(.+$)/g'
+        '/\\b@?TODO:?(.+$)/g'
         'CHANGEDs'
-        '/CHANGED:?(.+$)/g'
+        '/\\b@?CHANGED:?(.+$)/g'
         'XXXs'
-        '/XXX:?(.+$)/g'
+        '/\\b@?XXX:?(.+$)/g'
+        'IDEAs'
+        '/\\b@?IDEA:?(.+$)/g'
+        'HACKs'
+        '/\\b@?HACK:?(.+$)/g'
+        'NOTEs'
+        '/\\b@?NOTE:?(.+$)/g'
+        'REVIEWs'
+        '/\\b@?REVIEW:?(.+$)/g'
       ]
       items:
         type: 'string'

--- a/spec/fixtures/sample1/sample.js
+++ b/spec/fixtures/sample1/sample.js
@@ -22,4 +22,41 @@ var quicksort = function () {
   return sort(Array.apply(this, arguments));  // DEBUG
 
   // FIXME: Add more annnotations :)
+
+  // CHANGED one
+  // CHANGED: two
+  // @CHANGED three
+  // @CHANGED: four
+  // changed: non-matching tag
+
+  // XXX one
+  // XXX: two
+  // @XXX three
+  // @XXX: four
+  //xxx: non-matching tag
+
+  // IDEA one
+  // IDEA: two
+  // @IDEA three
+  // @IDEA: four
+  //idea: non-matching tag
+
+  // HACK one
+  // HACK: two
+  // @HACK three
+  // @HACK: four
+  //hack: non-matching tag
+
+  // NOTE one
+  // NOTE: two
+  // @NOTE three
+  // @NOTE: four
+  //note: non-matching tag
+
+  // REVIEW one
+  // REVIEW: two
+  // @REVIEW three
+  // @REVIEW: four
+  //review: non-matching tag
+
 };

--- a/spec/fixtures/saved-output.md
+++ b/spec/fixtures/saved-output.md
@@ -8,3 +8,45 @@
 - Comment in C _(sample.c)_
 - This is the first todo _(sample.js)_
 - This is the second todo _(sample.js)_
+
+## CHANGEDs
+
+- one _(sample.js)_
+- two _(sample.js)_
+- three _(sample.js)_
+- four _(sample.js)_
+
+## XXXs
+
+- one _(sample.js)_
+- two _(sample.js)_
+- three _(sample.js)_
+- four _(sample.js)_
+
+## IDEAs
+
+- one _(sample.js)_
+- two _(sample.js)_
+- three _(sample.js)_
+- four _(sample.js)_
+
+## HACKs
+
+- one _(sample.js)_
+- two _(sample.js)_
+- three _(sample.js)_
+- four _(sample.js)_
+
+## NOTEs
+
+- one _(sample.js)_
+- two _(sample.js)_
+- three _(sample.js)_
+- four _(sample.js)_
+
+## REVIEWs
+
+- one _(sample.js)_
+- two _(sample.js)_
+- three _(sample.js)_
+- four _(sample.js)_


### PR DESCRIPTION
Fixes #55. Updates RegExp patterns to mimic those from [atom/language-todo](https://github.com/atom/language-todo) and includes some simple tests for the new ones.
